### PR TITLE
Return targets asynchronously

### DIFF
--- a/lib/build-stack.js
+++ b/lib/build-stack.js
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import EventEmitter from 'events';
 import consistentEnv from 'consistent-env';
-import child_process from 'child_process';
+import {spawn} from 'child-process-promise';
 import {CompositeDisposable} from 'atom';
 
 let subscriptions = null;
@@ -49,19 +49,18 @@ class StackBuilder extends EventEmitter {
       env: consistentEnv(),
       errorMatch: [ '(?<file>.+\\.l?hs):(?<line>\\d+):(?<col>\\d+):' ]
     };
-
-    const proc = child_process.spawnSync('stack', [ 'ide', 'packages' ], {cwd: this.cwd});
-    return [ all ]
-      .concat(proc.stdout.toString().split('\n')
-      .filter(name => name !== '')
-      .map(name => ({
-        name: name,
-        exec: 'stack',
-        args: [ 'build', name ],
-        sh: false,
-        env: consistentEnv(),
-        errorMatch: [ '(?<file>.+\\.l?hs):(?<line>\\d+):(?<col>\\d+):' ]
-      })));
+    return spawn('stack', [ 'ide', 'packages' ], { cwd: this.cwd, capture: [ 'stdout' ] })
+      .then(result => [ all ].concat(
+        result.stdout.toString().split('\n')
+        .filter(name => name !== '')
+        .map(name => ({
+          name: name,
+          exec: 'stack',
+          args: [ 'build', name ],
+          sh: false,
+          env: consistentEnv(),
+          errorMatch: [ '(?<file>.+\\.l?hs):(?<line>\\d+):(?<col>\\d+):' ]
+        }))));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
+    "child-process-promise": "^1.1.0",
     "consistent-env": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This was pretty quick in practice, but there’s no reason for us to block here.
