### PR TITLE
Make error matcher work for projects with several targets.

### DIFF
--- a/lib/build-stack.js
+++ b/lib/build-stack.js
@@ -47,7 +47,7 @@ class StackBuilder extends EventEmitter {
       args: [ 'build' ],
       sh: false,
       env: consistentEnv(),
-      errorMatch: [ '(?<file>.+\\.l?hs):(?<line>\\d+):(?<col>\\d+):' ]
+      errorMatch: [ ' *(?<file>.+\\.l?hs):(?<line>\\d+):(?<col>\\d+):' ]
     };
     return spawn('stack', [ 'ide', 'packages' ], { cwd: this.cwd, capture: [ 'stdout' ] })
       .then(result => [ all ].concat(


### PR DESCRIPTION
Errors sometimes have extra indentation before them.
For example when running "stack build" for Lamdu (https://github.com/lamdu/lamdu).
This may be because its stack.yaml defines several targets?
